### PR TITLE
Fixed when Alpa channel is zero, letters were invisible in such cases.

### DIFF
--- a/IgniteCaptcha/IgniteCaptcha.cs
+++ b/IgniteCaptcha/IgniteCaptcha.cs
@@ -101,6 +101,7 @@ namespace RMorais.IgniteCaptcha
                 mst.ToArray()[paran].Name,
                 BindingFlags.GetField, null, null, new object[] { });
             result = b;
+            result.A = 0xFF;
 
             return result;
         }


### PR DESCRIPTION
If you open your test example and start continuously F5-ing you will see that some times a letter or two is missing and that space is unoccupied. I debugged it and found that Alpha channel of the color was 0 in such cases.

The proposed change forces it to always be non-transparent.